### PR TITLE
stretched images of members on team page were fixed

### DIFF
--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -1600,3 +1600,7 @@ section {
   font-size: 13px;
   color: #fff;
 }
+img.img-fluid {
+    object-fit: cover;
+    object-position: center center;
+}


### PR DESCRIPTION
# BEFORE:
![image](https://user-images.githubusercontent.com/60546840/105521891-6174f400-5c91-11eb-8632-ee3dfb636ee0.png)
![image](https://user-images.githubusercontent.com/60546840/105521989-86696700-5c91-11eb-924c-e829622130aa.png)

# AFTER:
![image](https://user-images.githubusercontent.com/60546840/105521866-56ba5f00-5c91-11eb-9712-4ef2a593d887.png)
![image](https://user-images.githubusercontent.com/60546840/105522046-9b45fa80-5c91-11eb-8094-053ccc4c50e7.png)
